### PR TITLE
feat: migrate to material-ui v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,16 +54,16 @@
   "dependencies": {
     "@devexpress/dx-react-grid": "^1.10.5",
     "@devexpress/dx-react-grid-material-ui": "^1.10.5",
-    "@material-ui/core": "^3.9.3",
-    "@material-ui/icons": "^3.0.2",
+    "@material-ui/core": "^4.0.1",
+    "@material-ui/icons": "^4.0.1",
     "classnames": "^2.2.6",
     "lodash": "^4.17.11",
-    "react-router-dom": "^5.0.0",
     "notistack": "^0.8.3",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.0.3",
+    "react-router-dom": "^5.0.0",
     "redux": "^4.0.1"
   }
 }

--- a/src/ButtonList/__snapshots__/ButtonList.test.js.snap
+++ b/src/ButtonList/__snapshots__/ButtonList.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ButtonList-bottom matches the snapshot - alignBottom 1`] = `
 <div>
   <div
-    class="MuiGrid-item-109 ButtonList-root-103 ButtonList-alignBottom-105"
+    class="MuiGrid-root ButtonList-root-109 ButtonList-alignBottom-111 MuiGrid-item"
   >
     <button
       type="submit"
@@ -27,7 +27,7 @@ exports[`ButtonList-bottom matches the snapshot - alignBottom 1`] = `
 exports[`ButtonList-top matches the snapshot - alignTop 1`] = `
 <div>
   <div
-    class="MuiGrid-item-7 ButtonList-root-1 ButtonList-alignTop-2"
+    class="MuiGrid-root ButtonList-root-1 ButtonList-alignTop-2 MuiGrid-item"
   >
     <button
       type="submit"

--- a/src/FlexHeader/__snapshots__/FlexHeader.test.js.snap
+++ b/src/FlexHeader/__snapshots__/FlexHeader.test.js.snap
@@ -3,7 +3,7 @@
 exports[`FlexHeader matches the snapshot with borderBottom prop 1`] = `
 <div>
   <div
-    class="MuiGrid-container-207 FlexHeader-root-203 FlexHeader-borderBottom-205"
+    class="MuiGrid-root FlexHeader-root-215 FlexHeader-borderBottom-217 MuiGrid-container"
     data-testid="flex-header"
   >
     <div>
@@ -16,7 +16,7 @@ exports[`FlexHeader matches the snapshot with borderBottom prop 1`] = `
 exports[`FlexHeader matches the snapshot with both marginTop and borderBottom prop 1`] = `
 <div>
   <div
-    class="MuiGrid-container-308 FlexHeader-root-304 FlexHeader-borderBottom-306 FlexHeader-marginTop-305"
+    class="MuiGrid-root FlexHeader-root-322 FlexHeader-borderBottom-324 FlexHeader-marginTop-323 MuiGrid-container"
     data-testid="flex-header"
   >
     <div
@@ -31,7 +31,7 @@ exports[`FlexHeader matches the snapshot with both marginTop and borderBottom pr
 exports[`FlexHeader matches the snapshot with marginTop prop 1`] = `
 <div>
   <div
-    class="MuiGrid-container-106 FlexHeader-root-102 FlexHeader-marginTop-103"
+    class="MuiGrid-root FlexHeader-root-108 FlexHeader-marginTop-109 MuiGrid-container"
     data-testid="flex-header"
   >
     <div>
@@ -44,7 +44,7 @@ exports[`FlexHeader matches the snapshot with marginTop prop 1`] = `
 exports[`FlexHeader matches the snapshot with no props 1`] = `
 <div>
   <div
-    class="MuiGrid-container-5 FlexHeader-root-1"
+    class="MuiGrid-root FlexHeader-root-1 MuiGrid-container"
     data-testid="flex-header"
   >
     <div>

--- a/src/ListItemDetail/__snapshots__/ListItemDetail.test.js.snap
+++ b/src/ListItemDetail/__snapshots__/ListItemDetail.test.js.snap
@@ -3,24 +3,24 @@
 exports[`ListItemDetail component matches snapshot with a label prop 1`] = `
 <div>
   <li
-    class="MuiListItem-root-3 MuiListItem-default-6 MuiListItem-gutters-11"
+    class="MuiListItem-root MuiListItem-gutters"
   >
     <div
-      class="MuiListItemText-root-15 ListItemDetail-item-2"
+      class="MuiListItemText-root ListItemDetail-item-2"
       data-testid="label-list-text"
     >
       <span
-        class="MuiTypography-root-21 MuiTypography-subheading-28 ListItemDetail-label-1"
+        class="MuiTypography-root MuiTypography-body1 ListItemDetail-label-1"
       >
         TestLabel
       </span>
     </div>
     <div
-      class="MuiListItemText-root-15"
+      class="MuiListItemText-root"
       data-testid="value-list-text"
     >
       <span
-        class="MuiTypography-root-21 MuiTypography-subheading-28 MuiListItemText-primary-18"
+        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary"
       >
         TestValue
       </span>

--- a/src/PopupFormButton/__snapshots__/PopupFormButton.test.js.snap
+++ b/src/PopupFormButton/__snapshots__/PopupFormButton.test.js.snap
@@ -3,18 +3,18 @@
 exports[`PopupFormButton matches the snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root-31 MuiButton-root-5 MuiButton-outlined-13"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined"
     data-testid="popup-button"
     tabindex="0"
     type="button"
   >
     <span
-      class="MuiButton-label-6"
+      class="MuiButton-label"
     >
       Submit
     </span>
     <span
-      class="MuiTouchRipple-root-34"
+      class="MuiTouchRipple-root"
     />
   </button>
 </div>

--- a/src/PrimaryNavigation/__snapshots__/PrimaryNavigation.test.js.snap
+++ b/src/PrimaryNavigation/__snapshots__/PrimaryNavigation.test.js.snap
@@ -3,18 +3,19 @@
 exports[`PrimaryNavigation matches the snapshot 1`] = `
 <div>
   <a
-    class="MuiButtonBase-root-29 MuiButton-root-3 MuiButton-text-5 MuiButton-flat-8 PrimaryNavigation-button-1"
+    aria-disabled="false"
+    class="MuiButtonBase-root MuiButton-root PrimaryNavigation-button-1 MuiButton-text"
     href="/login"
     role="button"
     tabindex="0"
   >
     <span
-      class="MuiButton-label-4"
+      class="MuiButton-label"
     >
       Login
     </span>
     <span
-      class="MuiTouchRipple-root-32"
+      class="MuiTouchRipple-root"
     />
   </a>
 </div>

--- a/src/SubTitle/__snapshots__/SubTitle.test.js.snap
+++ b/src/SubTitle/__snapshots__/SubTitle.test.js.snap
@@ -3,13 +3,13 @@
 exports[`SubTitle component matches snapshot with a label prop 1`] = `
 <div>
   <span
-    class="MuiTypography-root-2 MuiTypography-overline-22 MuiTypography-gutterBottom-29 SubTitle-label-1"
+    class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom SubTitle-label-1"
     data-testid="subtitle-label"
   >
     Partner: 
   </span>
   <h6
-    class="MuiTypography-root-2 MuiTypography-subtitle1-20 MuiTypography-gutterBottom-29"
+    class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-gutterBottom"
     data-testid="subtitle-content"
   >
     Partner1
@@ -20,7 +20,7 @@ exports[`SubTitle component matches snapshot with a label prop 1`] = `
 exports[`SubTitle component matches snapshot without a label prop 1`] = `
 <div>
   <h6
-    class="MuiTypography-root-39 MuiTypography-subtitle1-57 MuiTypography-gutterBottom-66"
+    class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-gutterBottom"
     data-testid="subtitle-content"
   >
     Partner1

--- a/src/WorkflowStatus/__snapshots__/WorkflowStatus.test.js.snap
+++ b/src/WorkflowStatus/__snapshots__/WorkflowStatus.test.js.snap
@@ -3,25 +3,25 @@
 exports[`WorkflowStatus matches the snapshot with label prop 1`] = `
 <div>
   <div
-    class="MuiGrid-item-6 WorkflowStatus-grow-4"
+    class="MuiGrid-root WorkflowStatus-grow-4 MuiGrid-item"
   >
     <div
-      class="MuiGrid-container-5"
+      class="MuiGrid-root MuiGrid-container"
     >
       <span
-        class="MuiTypography-root-102 MuiTypography-overline-122 MuiTypography-gutterBottom-129 WorkflowStatus-label-2"
+        class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom WorkflowStatus-label-2"
         data-testid="workflow-label"
       >
         Agreement Status
       </span>
       <span
-        class="MuiTypography-root-102 MuiTypography-overline-122 MuiTypography-gutterBottom-129 WorkflowStatusItem-inactive-139 WorkflowStatusItem-declinedStatus-140"
+        class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom WorkflowStatusItem-inactive-139 WorkflowStatusItem-declinedStatus-140"
       >
         Declined
       </span>
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root-144 WorkflowStatus-arrow-3"
+        class="MuiSvgIcon-root WorkflowStatus-arrow-3"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"
@@ -35,13 +35,13 @@ exports[`WorkflowStatus matches the snapshot with label prop 1`] = `
         />
       </svg>
       <span
-        class="MuiTypography-root-102 MuiTypography-overline-122 MuiTypography-gutterBottom-129 WorkflowStatusItem-active-138 WorkflowStatusItem-draftStatus-141"
+        class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom WorkflowStatusItem-active-138 WorkflowStatusItem-draftStatus-141"
       >
         Draft
       </span>
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root-144 WorkflowStatus-arrow-3"
+        class="MuiSvgIcon-root WorkflowStatus-arrow-3"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"
@@ -55,13 +55,13 @@ exports[`WorkflowStatus matches the snapshot with label prop 1`] = `
         />
       </svg>
       <span
-        class="MuiTypography-root-102 MuiTypography-overline-122 MuiTypography-gutterBottom-129 WorkflowStatusItem-inactive-139 WorkflowStatusItem-pendingStatus-142"
+        class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom WorkflowStatusItem-inactive-139 WorkflowStatusItem-pendingStatus-142"
       >
         Pending
       </span>
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root-144 WorkflowStatus-arrow-3"
+        class="MuiSvgIcon-root WorkflowStatus-arrow-3"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"
@@ -75,7 +75,7 @@ exports[`WorkflowStatus matches the snapshot with label prop 1`] = `
         />
       </svg>
       <span
-        class="MuiTypography-root-102 MuiTypography-overline-122 MuiTypography-gutterBottom-129 WorkflowStatusItem-inactive-139 WorkflowStatusItem-acceptedStatus-143"
+        class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom WorkflowStatusItem-inactive-139 WorkflowStatusItem-acceptedStatus-143"
       >
         Accepted
       </span>
@@ -87,19 +87,19 @@ exports[`WorkflowStatus matches the snapshot with label prop 1`] = `
 exports[`WorkflowStatus matches the snapshot without label prop 1`] = `
 <div>
   <div
-    class="MuiGrid-item-158 WorkflowStatus-grow-156"
+    class="MuiGrid-root WorkflowStatus-grow-156 MuiGrid-item"
   >
     <div
-      class="MuiGrid-container-157"
+      class="MuiGrid-root MuiGrid-container"
     >
       <span
-        class="MuiTypography-root-260 MuiTypography-overline-280 MuiTypography-gutterBottom-287 WorkflowStatusItem-inactive-255 WorkflowStatusItem-declinedStatus-256"
+        class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom WorkflowStatusItem-inactive-261 WorkflowStatusItem-declinedStatus-262"
       >
         Declined
       </span>
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root-296 WorkflowStatus-arrow-155"
+        class="MuiSvgIcon-root WorkflowStatus-arrow-155"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"
@@ -113,13 +113,13 @@ exports[`WorkflowStatus matches the snapshot without label prop 1`] = `
         />
       </svg>
       <span
-        class="MuiTypography-root-260 MuiTypography-overline-280 MuiTypography-gutterBottom-287 WorkflowStatusItem-active-254 WorkflowStatusItem-draftStatus-257"
+        class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom WorkflowStatusItem-active-260 WorkflowStatusItem-draftStatus-263"
       >
         Draft
       </span>
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root-296 WorkflowStatus-arrow-155"
+        class="MuiSvgIcon-root WorkflowStatus-arrow-155"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"
@@ -133,13 +133,13 @@ exports[`WorkflowStatus matches the snapshot without label prop 1`] = `
         />
       </svg>
       <span
-        class="MuiTypography-root-260 MuiTypography-overline-280 MuiTypography-gutterBottom-287 WorkflowStatusItem-inactive-255 WorkflowStatusItem-pendingStatus-258"
+        class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom WorkflowStatusItem-inactive-261 WorkflowStatusItem-pendingStatus-264"
       >
         Pending
       </span>
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root-296 WorkflowStatus-arrow-155"
+        class="MuiSvgIcon-root WorkflowStatus-arrow-155"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"
@@ -153,7 +153,7 @@ exports[`WorkflowStatus matches the snapshot without label prop 1`] = `
         />
       </svg>
       <span
-        class="MuiTypography-root-260 MuiTypography-overline-280 MuiTypography-gutterBottom-287 WorkflowStatusItem-inactive-255 WorkflowStatusItem-acceptedStatus-259"
+        class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom WorkflowStatusItem-inactive-261 WorkflowStatusItem-acceptedStatus-265"
       >
         Accepted
       </span>

--- a/src/WorkflowStatusItem/__snapshots__/WorkflowStatusItem.test.js.snap
+++ b/src/WorkflowStatusItem/__snapshots__/WorkflowStatusItem.test.js.snap
@@ -3,7 +3,7 @@
 exports[`WorkflowStatusItem matches the snapshot 1`] = `
 <div>
   <span
-    class="MuiTypography-root-7 MuiTypography-overline-27 MuiTypography-gutterBottom-34 WorkflowStatusItem-active-1 WorkflowStatusItem-draftStatus-4"
+    class="MuiTypography-root MuiTypography-overline MuiTypography-gutterBottom WorkflowStatusItem-active-1 WorkflowStatusItem-draftStatus-4"
   >
     test
   </span>


### PR DESCRIPTION
BREAKING CHANGE: Components may or may not work with versions
of material-ui < v4. Safest bet would be to update your app to
use material-ui v4 before upgrading to this version of cod-ui.
