### PR TITLE
fix: update PopupFormButton Icon prop type

### DIFF
--- a/src/PopupFormButton/PopupFormButton.js
+++ b/src/PopupFormButton/PopupFormButton.js
@@ -72,10 +72,10 @@ const PopupFormButton = props => {
 };
 
 PopupFormButton.propTypes = {
-  Form: PropTypes.func.isRequired,
+  Form: PropTypes.elementType.isRequired,
   ButtonProps: PropTypes.shape({}),
   buttonText: PropTypes.string,
-  Icon: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  Icon: PropTypes.elementType,
   /**
    * Any props you want to pass into the form component.
    */


### PR DESCRIPTION
### Related Ticket

<!-- Please link to the github issue here. -->

https://github.com/codfish/cod-ui/issues/32

### Description

The Icon prop should be elementType in order to be able to pass in a material-ui icon.

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have reviewed the code changes myself
- [x] My code meets all of the acceptance criteria of the issue it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have added/updated `StyleGuide` documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Any dependent changes have been merged and published.
