### PR TITLE
fix: update spacing prop value in ErrorBoundary

### DIFF
--- a/src/pages/ErrorBoundary.js
+++ b/src/pages/ErrorBoundary.js
@@ -29,7 +29,7 @@ class ErrorBoundary extends React.Component {
     if (hasError) {
       return (
         <Grid container>
-          <Grid container justify="center" spacing={16}>
+          <Grid container justify="center" spacing={2}>
             <Typography variant="h2" component="h2" className={classes.text}>
               Something went wrong.
             </Typography>


### PR DESCRIPTION
### Related Ticket

<!-- Please link to the github issue here. -->

https://github.com/codfish/cod-ui/issues/34

### Description

Update the spacing prop value in ErrorBoundary because of breaking changes in the material-ui upgrade

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have reviewed the code changes myself
- [x] My code meets all of the acceptance criteria of the issue it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have added/updated `StyleGuide` documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Any dependent changes have been merged and published.
