### PR TITLE
Remove unnecessary classes proptype in Loader

### DIFF
--- a/src/Loader/Loader.js
+++ b/src/Loader/Loader.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import useStyles from './styles';
 
 function Loader() {
@@ -19,13 +18,5 @@ function Loader() {
     </div>
   );
 }
-
-Loader.propTypes = {
-  classes: PropTypes.shape({
-    loadContainer: PropTypes.string,
-    loadHolder: PropTypes.string,
-    loadBox: PropTypes.string,
-  }).isRequired,
-};
 
 export default Loader;


### PR DESCRIPTION
### Related Ticket

<!-- Please link to the github issue here. -->

https://github.com/codfish/cod-ui/issues/38

### Description

Got a warning on Loader.js, classes is no longer a prop

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [ ] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the issue it closes.
- [ ] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have added/updated `StyleGuide` documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
