### PR TITLE
feat: update devexpress dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "prettier": "^1.18.2"
   },
   "dependencies": {
-    "@devexpress/dx-react-core": "^1.11.0",
-    "@devexpress/dx-react-grid": "^1.10.5",
-    "@devexpress/dx-react-grid-material-ui": "^1.10.5",
+    "@devexpress/dx-react-core": "^2.0.0",
+    "@devexpress/dx-react-grid": "^2.0.0",
+    "@devexpress/dx-react-grid-material-ui": "^2.0.0",
     "@material-ui/core": "^4.1.1",
     "@material-ui/icons": "^4.2.0",
     "@material-ui/styles": "^4.1.1",


### PR DESCRIPTION
BREAKING CHANGE: Update devexpress to v2.0.0
removes material-ui warnings
closes #40

### Related Ticket

<!-- Please link to the github issue here. -->

#40

### Description

<!-- Brief description of the code changes. Add supporting screenshots & videos where applicable. -->

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [ ] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the issue it closes.
- [ ] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have added/updated `StyleGuide` documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
