### PR TITLE
test: add missing user.name prop to primaryNavigation test

### DIFF
--- a/src/PrimaryNavigation/PrimaryNavigation.test.js
+++ b/src/PrimaryNavigation/PrimaryNavigation.test.js
@@ -12,7 +12,7 @@ describe('PrimaryNavigation', () => {
     const { getByTestId } = renderWithProviders(
       <PrimaryNavigation
         {...{
-          user: { email: 'foo' },
+          user: { email: 'foo', name: 'foo' },
           mainNav: [{ label: 'Partners', href: 'http://partner' }],
           onLogout() {},
         }}


### PR DESCRIPTION
removes test warning
closes #52

### Related Ticket

<!-- Please link to the github issue here. -->

#52 

### Description

Removes warning during tests.

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have reviewed the code changes myself
- [x] My code meets all of the acceptance criteria of the issue it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have added/updated `StyleGuide` documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Any dependent changes have been merged and published.
